### PR TITLE
Add support for additional platforms in manifest

### DIFF
--- a/internal/module/info/manifest.json
+++ b/internal/module/info/manifest.json
@@ -29,6 +29,9 @@
   ],
   "platforms": [
     "linux/amd64"
+    "darwin/amd64",
+    "darwin/arm64",
+    "windows/amd64"
   ],
   "dependencies": [
     "tar",


### PR DESCRIPTION
This pull request updates the supported platforms in the `manifest.json` file to expand compatibility beyond Linux. The most important change is the addition of macOS (both Intel and Apple Silicon) and Windows platforms.

Platform support expansion:

* Added support for `darwin/amd64`, `darwin/arm64`, and `windows/amd64` to the `platforms` list in `internal/module/info/manifest.json`, enabling the module to run on macOS (both Intel and Apple Silicon) and Windows systems.